### PR TITLE
Reorder Linux ncurses library list to support modern operating system revisions.

### DIFF
--- a/dotnet-curses/Support/CursesLibraryNames.cs
+++ b/dotnet-curses/Support/CursesLibraryNames.cs
@@ -34,7 +34,7 @@ namespace Mindmagma.Curses
         /// for OSPlatform.Linux. Override this to add to the defaults, or
         /// also override the Replace property to replace the defaults.
         /// </summary>
-        public virtual List<string> NamesLinux => new List<string> { "libncurses.so.5.9", "libncurses.so" };
+        public virtual List<string> NamesLinux => new List<string> { "libncurses.so", "libncurses.so.6", "libncurses.so.5.9" };
 
         /// <summary>
         /// Defaults to false, override this to set it to true which ignores


### PR DESCRIPTION
The base library name should be first, as it is symlinked to the default version if it exists. This is the case on most distributions.
If the name sans version numbers is not available, the current ncurses version is 6.2. This is usually symlinked as `.so.6`. `.so.5.9` still exists for some old distros, so no need to remove it.