### PR TITLE
 Implement `HalfDelay` and companion functions `TimeOut` and `WindowTimeOut`.

### DIFF
--- a/dotnet-curses/NativeWrapper/NativeEnvironment.cs
+++ b/dotnet-curses/NativeWrapper/NativeEnvironment.cs
@@ -63,5 +63,15 @@ namespace Mindmagma.Curses.Interop
         private delegate int dt_raw();
         private static dt_raw call_raw = NativeToDelegate<dt_raw>("raw");
         internal static int raw() => call_raw();
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_halfdelay(int tenths);
+        private static dt_halfdelay call_halfdelay = NativeToDelegate<dt_halfdelay>("halfdelay");
+        internal static int halfdelay(int tenths) => call_halfdelay(tenths);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_timeout(int delay);
+        private static dt_timeout call_timeout = NativeToDelegate<dt_timeout>("timeout");
+        internal static int timeout(int delay) => call_timeout(delay);
     }
 }

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -83,7 +83,7 @@ namespace Mindmagma.Curses.Interop
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_wtimeout(IntPtr window, int delay);
-        private static dt_wtimeout call_wtimeout = NativeToDelegate<dt_wtimeout("wtimeout");
+        private static dt_wtimeout call_wtimeout = NativeToDelegate<dt_wtimeout>("wtimeout");
         internal static int wtimeout(IntPtr window, int delay) => call_wtimeout(window, delay);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -82,6 +82,11 @@ namespace Mindmagma.Curses.Interop
         internal static int nodelay(IntPtr window, bool removeDelay) => call_nodelay(window, removeDelay);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_wtimeout(IntPtr window, int delay);
+        private static dt_wtimeout call_wtimeout = NativeToDelegate<dt_wtimeout("wtimeout");
+        internal static int wtimeout(IntPtr window, int delay) => call_wtimeout(window, delay);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_overlay(IntPtr sourceWindow, IntPtr destinationWindow);
         private static dt_overlay call_overlay = NativeToDelegate<dt_overlay>("overlay");
         internal static int overlay(IntPtr sourceWindow, IntPtr destinationWindow) => call_overlay(sourceWindow, destinationWindow);

--- a/dotnet-curses/PublicApi/NCursesEnvironment.cs
+++ b/dotnet-curses/PublicApi/NCursesEnvironment.cs
@@ -85,5 +85,26 @@ namespace Mindmagma.Curses
             int result = Native.raw();
             NativeExceptionHelper.ThrowOnFailure(result, nameof(Raw));
         }
+
+        /// <summary>
+        /// Sets input to half-delay mode where characters are immediately available for input but blocking for tenths of a second with no input ERR is returned.
+        /// </summary>
+        public static void HalfDelay(int tenths)
+        {
+            int result = Native.halfdelay(tenths);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(HalfDelay));
+        }
+
+        /// <summary>
+        /// Sets blocking or non-blocking mode.
+        /// If delay is negative, blocking read is used.
+        /// If delay is zero, non-blocking read is used and no input waiting returns ERR.
+        /// If delay is positive, read blocks for delay milliseconds and then returns ERR if there is still no input.
+        /// </summary>
+        public static void TimeOut(int delay)
+        {
+            int result = Native.timeout(delay);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(TimeOut));
+        }
     }
 }

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -95,6 +95,12 @@ namespace Mindmagma.Curses
             NativeExceptionHelper.ThrowOnFailure(result, nameof(NoDelay));
         }
 
+        public static void WindowTimeOut(IntPtr window, int delay)
+        {
+            int result = Native.wtimout(window, delay);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowTimeOut));
+        }
+
         public static void Overlay(IntPtr sourceWindow, IntPtr destinationWindow)
         {
             int result = Native.overlay(sourceWindow, destinationWindow);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -97,7 +97,7 @@ namespace Mindmagma.Curses
 
         public static void WindowTimeOut(IntPtr window, int delay)
         {
-            int result = Native.wtimout(window, delay);
+            int result = Native.wtimeout(window, delay);
             NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowTimeOut));
         }
 

--- a/dotnet-curses/dotnet-curses.csproj
+++ b/dotnet-curses/dotnet-curses.csproj
@@ -5,14 +5,14 @@
     <RootNamespace>Mindmagma.Curses</RootNamespace>
     <Description>Portable cross-platform .NET Standard wrapper for the Unix ncurses library</Description>
     <Authors>Jon McGuire</Authors>
-    <PackageVersion>1.0.2</PackageVersion>
+    <PackageVersion>1.0.3</PackageVersion>
     <PackageId>dotnet-curses</PackageId>
     <PackageTags>curses;ncurses</PackageTags>
     <PackageLicenseUrl>https://github.com/MV10/dotnet-curses/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/MV10/dotnet-curses/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/MV10/dotnet-curses/</RepositoryUrl>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
The native interface was missing calls to enable half-blocking input mode.
Added native wrappers and public functions.
Increment version to `1.0.3` because new functions were added.