### PR TITLE
Implement wrappers for some missing curses windows functions

### DIFF
--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -132,6 +132,16 @@ namespace Mindmagma.Curses.Interop
         internal static int waddnstr(IntPtr win, String str, int n) => call_waddnstr(win, str, n);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_wattron(IntPtr window, uint attributes);
+        private static dt_wattron call_wattron = NativeToDelegate<dt_wattron>("wattron");
+        internal static int wattron(IntPtr window, uint attributes) => call_wattron(window, attributes);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_wattroff(IntPtr window, uint attributes);
+        private static dt_wattron call_wattroff = NativeToDelegate<dt_wattron>("wattroff");
+        internal static int wattroff(IntPtr window, uint attributes) => call_wattroff(window, attributes);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_wbkgd(IntPtr window, uint ch);
         private static dt_wbkgd call_wbkgd = NativeToDelegate<dt_wbkgd>("wbkgd");
         internal static int wbkgd(IntPtr window, uint ch) => call_wbkgd(window, ch);

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -62,6 +62,11 @@ namespace Mindmagma.Curses.Interop
         internal static int keypad(IntPtr window, bool enable) => call_keypad(window, enable);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_mvwaddch(IntPtr window, int y, int x, char c);
+        private static dt_mvwaddch call_mvwaddch = NativeToDelegate<dt_mvwaddch>("mvwaddch");
+        internal static int mvwaddch(IntPtr window, int y, int x, char c) => call_mvwaddch(window, y, x, c);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_mvwaddstr(IntPtr window, int y, int x, string message);
         private static dt_mvwaddstr call_mvwaddstr = NativeToDelegate<dt_mvwaddstr>("mvwaddstr");
         internal static int mvwaddstr(IntPtr window, int y, int x, string message) => call_mvwaddstr(window, y, x, message);

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -148,8 +148,13 @@ namespace Mindmagma.Curses.Interop
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_wattroff(IntPtr window, uint attributes);
-        private static dt_wattron call_wattroff = NativeToDelegate<dt_wattron>("wattroff");
+        private static dt_wattroff call_wattroff = NativeToDelegate<dt_wattroff>("wattroff");
         internal static int wattroff(IntPtr window, uint attributes) => call_wattroff(window, attributes);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_wattrset(IntPtr window, uint attributes);
+        private static dt_wattrset call_wattrset = NativeToDelegate<dt_wattrset>("wattrset");
+        internal static int wattrset(IntPtr window, uint attributes) => call_wattrset(window, attributes);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_wbkgd(IntPtr window, uint ch);

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -72,6 +72,11 @@ namespace Mindmagma.Curses.Interop
         internal static int mvwin(IntPtr window, int row, int column) => call_mvwin(window, row, column);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_mvwgetch(IntPtr window, int y, int x);
+        private static dt_mvwgetch call_mvwgetch = NativeToDelegate<dt_mvwgetch>("mvwgetch");
+        internal static int mvwgetch(IntPtr window, int y, int x) => call_mvwgetch(window, y, x);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate IntPtr dt_newwin(int rows, int columns, int yOrigin, int xOrigin);
         private static dt_newwin call_newwin = NativeToDelegate<dt_newwin>("newwin");
         internal static IntPtr newwin(int rows, int columns, int yOrigin, int xOrigin) => call_newwin(rows, columns, yOrigin, xOrigin);

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -163,6 +163,11 @@ namespace Mindmagma.Curses.Interop
         internal static int wgetch(IntPtr win) => call_wgetch(win);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate int dt_wmove(IntPtr window, int row, int column);
+        private static dt_wmove call_wmove = NativeToDelegate<dt_wmove>("wmove");
+        internal static int wmove(IntPtr window, int row, int column) => call_wmove(window, row, column);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_wrefresh(IntPtr win);
         private static dt_wrefresh call_wrefresh = NativeToDelegate<dt_wrefresh>("wrefresh");
         internal static int wrefresh(IntPtr win) => call_wrefresh(win);

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -82,6 +82,11 @@ namespace Mindmagma.Curses.Interop
         internal static int mvwgetch(IntPtr window, int y, int x) => call_mvwgetch(window, y, x);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate uint dt_mvwinch(IntPtr window, int y, int x);
+        private static dt_mvwinch call_mvwinch = NativeToDelegate<dt_mvwinch>("mvwinch");
+        internal static uint mvwinch(IntPtr window, int y, int x) => call_mvwinch(window, y, x);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate IntPtr dt_newwin(int rows, int columns, int yOrigin, int xOrigin);
         private static dt_newwin call_newwin = NativeToDelegate<dt_newwin>("newwin");
         internal static IntPtr newwin(int rows, int columns, int yOrigin, int xOrigin) => call_newwin(rows, columns, yOrigin, xOrigin);

--- a/dotnet-curses/NativeWrapper/NativeWindow.cs
+++ b/dotnet-curses/NativeWrapper/NativeWindow.cs
@@ -183,6 +183,11 @@ namespace Mindmagma.Curses.Interop
         internal static int wgetch(IntPtr win) => call_wgetch(win);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        private delegate uint dt_winch(IntPtr window);
+        private static dt_winch call_winch = NativeToDelegate<dt_winch>("winch");
+        internal static uint winch(IntPtr window) => call_winch(window);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         private delegate int dt_wmove(IntPtr window, int row, int column);
         private static dt_wmove call_wmove = NativeToDelegate<dt_wmove>("wmove");
         internal static int wmove(IntPtr window, int row, int column) => call_wmove(window, row, column);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -181,6 +181,13 @@ namespace Mindmagma.Curses
             return result;
         }
 
+        public static int WindowAttributeSet(IntPtr window, uint attributes)
+        {
+            int result = Native.wattrset(window, attributes);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowAttributeSet));
+            return result;
+		}
+
         public static void WindowBackground(IntPtr window, uint ch)
         {
             int result = Native.wbkgd(window, ch);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -96,6 +96,13 @@ namespace Mindmagma.Curses
             return result;
         }
 
+        public static uint MoveWindowInspectChar(IntPtr window, int y, int x)
+        {
+            uint result = Native.mvwinch(window, y, x);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindowInspectChar));
+            return result;
+        }
+
         public static IntPtr NewWindow(int rows, int columns, int yOrigin, int xOrigin)
         {
             IntPtr result = Native.newwin(rows, columns, yOrigin, xOrigin);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -186,6 +186,12 @@ namespace Mindmagma.Curses
             return result;
         }
 
+        public static void WindowMove(IntPtr window, int row, int column)
+        {
+            int result = Native.wmove(window, row, column);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowMove));
+        }
+
         public static int WindowRefresh(IntPtr window)
         {
             int result = Native.wrefresh(window);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -82,6 +82,12 @@ namespace Mindmagma.Curses
             NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindow));
         }
 
+        public static void MoveWindowGetChar(IntPtr window, int y, int x)
+        {
+            int result = Native.mvwgetch(window, y, x);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindowGetChar));
+		}
+
         public static IntPtr NewWindow(int rows, int columns, int yOrigin, int xOrigin)
         {
             IntPtr result = Native.newwin(rows, columns, yOrigin, xOrigin);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -214,6 +214,13 @@ namespace Mindmagma.Curses
             return result;
         }
 
+        public static uint WindowInspectChar(IntPtr window)
+        {
+            uint result = Native.winch(window);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowInspectChar));
+            return result;
+        }
+
         public static int WindowMove(IntPtr window, int row, int column)
         {
             int result = Native.wmove(window, row, column);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -153,6 +153,20 @@ namespace Mindmagma.Curses
             return result;
         }
 
+        public static int WindowAttributeOn(IntPtr window, uint attributes)
+        {
+            int result = Native.wattron(window, attributes);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowAttributeOn));
+            return result;
+        }
+
+        public static int WindowAttributeOff(IntPtr window, uint attributes)
+        {
+            int result = Native.wattroff(window, attributes);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowAttributeOff));
+            return result;
+        }
+
         public static void WindowBackground(IntPtr window, uint ch)
         {
             int result = Native.wbkgd(window, ch);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -200,10 +200,11 @@ namespace Mindmagma.Curses
             return result;
         }
 
-        public static void WindowMove(IntPtr window, int row, int column)
+        public static int WindowMove(IntPtr window, int row, int column)
         {
             int result = Native.wmove(window, row, column);
             NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowMove));
+            return result;
         }
 
         public static int WindowRefresh(IntPtr window)

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -82,10 +82,11 @@ namespace Mindmagma.Curses
             NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindow));
         }
 
-        public static void MoveWindowGetChar(IntPtr window, int y, int x)
+        public static int MoveWindowGetChar(IntPtr window, int y, int x)
         {
             int result = Native.mvwgetch(window, y, x);
             NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindowGetChar));
+            return result;
 		}
 
         public static IntPtr NewWindow(int rows, int columns, int yOrigin, int xOrigin)

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -69,6 +69,13 @@ namespace Mindmagma.Curses
             NativeExceptionHelper.ThrowOnFailure(result, nameof(Keypad));
         }
 
+        public static int MoveWindowAddChar(IntPtr window, int y, int x, char c)
+        {
+            int result = Native.mvwaddch(window, y, x, c);
+            NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindowAddChar));
+            return result;
+		}
+
         public static int MoveWindowAddString(IntPtr window, int y, int x, string message)
         {
             int result = Native.mvwaddstr(window, y, x, message);

--- a/dotnet-curses/PublicApi/NCursesWindow.cs
+++ b/dotnet-curses/PublicApi/NCursesWindow.cs
@@ -74,7 +74,7 @@ namespace Mindmagma.Curses
             int result = Native.mvwaddch(window, y, x, c);
             NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindowAddChar));
             return result;
-		}
+        }
 
         public static int MoveWindowAddString(IntPtr window, int y, int x, string message)
         {
@@ -94,7 +94,7 @@ namespace Mindmagma.Curses
             int result = Native.mvwgetch(window, y, x);
             NativeExceptionHelper.ThrowOnFailure(result, nameof(MoveWindowGetChar));
             return result;
-		}
+        }
 
         public static IntPtr NewWindow(int rows, int columns, int yOrigin, int xOrigin)
         {
@@ -186,7 +186,7 @@ namespace Mindmagma.Curses
             int result = Native.wattrset(window, attributes);
             NativeExceptionHelper.ThrowOnFailure(result, nameof(WindowAttributeSet));
             return result;
-		}
+        }
 
         public static void WindowBackground(IntPtr window, uint ch)
         {

--- a/dotnet-curses/Support/NativeExceptionHelper.cs
+++ b/dotnet-curses/Support/NativeExceptionHelper.cs
@@ -18,6 +18,11 @@ namespace Mindmagma.Curses
             if (result == -1) throw new DotnetCursesException($"{method}() returned ERR");
         }
 
+        internal static void ThrowOnFailure(uint result, string method)
+        {
+            if (result == uint.MaxValue) throw new DotnetCursesException($"{method}() returned ERR");
+        }
+
         internal static void ThrowOnFailure(IntPtr result, string method)
         {
             if (result == IntPtr.Zero) throw new DotnetCursesException($"{method}() returned NULL");


### PR DESCRIPTION
Implemented wrappers for the following curses windows functions:
- `wattron`, `wattroff`, `wattrset`
- `wmove`
- `mvwgetch`
- `mvwaddch`
- `winch`, `mvwinch`